### PR TITLE
fixes undefined error for feature #54

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -14,9 +14,10 @@
   * @since 0.0.1
   */
 
-
+if (Meteor.isServer) {
 hangoutAlert = slack.extend({
     channel: Meteor.settings.slack_alert_channel,
     icon_emoji: ':bell:',
     username: Meteor.settings.slack_alert_username
   });
+}

--- a/server/api.js
+++ b/server/api.js
@@ -119,6 +119,7 @@ Meteor.methods({
         ]
     }
     // send Slack message to default channel (configured in Meteor settings)
+    /* global hangoutAlert from /lib/functions.js */
     hangoutAlert(data);
     return true;
   },


### PR DESCRIPTION
This is due to how the package creator exports the global variable and is not being made available on the server and client.  Workaround is to wrap it inside a `if (Meteor.isServer)` block.