### PR TITLE
Fix for issue #91. 500 error on multiple clicks on delete hangout

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -36,7 +36,6 @@ reactive-var
 simple:reactive-method
 peppelg:bootstrap-3-modal
 tsega:bootstrap3-datetimepicker
-kevohagan:sweetalert
 natestrauser:connection-banner
 tap:i18n
 copleykj:livestamp
@@ -50,3 +49,4 @@ georgediab:slack-notify
 erasaur:meteor-lodash
 
 
+patrickml:swal

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -49,7 +49,6 @@ http@1.1.1
 id-map@1.0.4
 joshowens:timezone-picker@0.1.2
 jquery@1.11.4
-kevohagan:sweetalert@1.0.0
 lai:collection-extensions@0.1.4
 launch-screen@1.0.4
 less@2.5.1
@@ -82,6 +81,7 @@ oauth@1.1.6
 oauth2@1.1.5
 observe-sequence@1.0.7
 ordered-dict@1.0.4
+patrickml:swal@1.0.0
 peppelg:bootstrap-3-modal@1.0.4
 promise@0.5.1
 raix:eventemitter@0.1.3

--- a/client/templates/hangout/hangout-item.html
+++ b/client/templates/hangout/hangout-item.html
@@ -2,14 +2,14 @@
   <div class="row hangout-item">
     <div class="col-md-10">
       <label class="name"><span>{{getIsDone this}}</span><a href="/hangout/{{_id}}" class="hangout-topic">
-          
+
           {{#if isInProgress this}}
             <!--<div id="placeholder-div-{{_id}}"></div>-->
             <i class="fa fa-dot-circle-o fa text-danger faa-burst animated"></i> &nbsp;
-            <button class="btn btn-default join-hangout" id="hangout-{{_id}}" href="">Join the hangout</button>
+            <!-- <button class="btn btn-default join-hangout" id="hangout-{{_id}}" href="">Join the hangout</button> -->
           {{/if}}
-              
-          {{topic}}</a> 
+
+          {{topic}}</a>
         {{#if isHost}}
         <div class="btn btn-default delete-hangout">
           <i class="fa fa-trash-o"></i>
@@ -22,7 +22,7 @@
       <ul class="status">
         <li><i class="fa {{getType type}}"></i></li>
         <li>
-          <label>{{getDate this}}  
+          <label>{{getDate this}}
             {{#if currentUser}}| <a class="clone-hangout">Copy</a>{{/if}}
           </label></li>
       </ul>

--- a/client/templates/hangout/hangout-item.js
+++ b/client/templates/hangout/hangout-item.js
@@ -1,13 +1,13 @@
-Meteor.startup(function () {
- /*Use reactive-var to make sure inProgress hangouts change automatically*/
-    reactiveDate = {
-      nowMinutes: new ReactiveVar(new Date)
-    };
+Meteor.startup(function() {
+  /*Use reactive-var to make sure inProgress hangouts change automatically*/
+  reactiveDate = {
+    nowMinutes: new ReactiveVar(new Date)
+  };
 
-    setInterval(function () {
-      reactiveDate.nowMinutes.set(new Date);
-    }, 60 * 1000); // every minute
- /*Hangout Links*/
+  setInterval(function() {
+    reactiveDate.nowMinutes.set(new Date);
+  }, 60 * 1000); // every minute
+  /*Hangout Links*/
 
 
 });
@@ -32,14 +32,14 @@ Template.hangoutItem.helpers({
     //console.log('getDate this.timestamp' + this.timestamp);
     //console.log('getDate this.end' + this.end)
     return 'host ' +
-            user +
-            ' | ' +
-            moment(hangout.start).tz(tz).format('MMMM Do YYYY, h:mm a z') +
-            ' - ' +
-            moment(hangout.end).tz(tz).format('h:mm a z') +
-            ' | ' +
-            hangout.users.length +
-            ' joined';
+      user +
+      ' | ' +
+      moment(hangout.start).tz(tz).format('MMMM Do YYYY, h:mm a z') +
+      ' - ' +
+      moment(hangout.end).tz(tz).format('h:mm a z') +
+      ' | ' +
+      hangout.users.length +
+      ' joined';
   },
   isInProgress: function(hangout) {
 
@@ -52,7 +52,7 @@ Template.hangoutItem.helpers({
     return this.users.indexOf(Meteor.userId()) != -1;
   },
 
-  isHost:  function () {
+  isHost: function() {
     return this.user_id === Meteor.userId();
   },
 
@@ -63,9 +63,13 @@ Template.hangoutItem.helpers({
     if (hangoutDate < currentDate) {
       var daysDiff = Math.round((currentDate - hangoutDate) / (1000 * 60 * 60 * 24));
       if (daysDiff == 0)
-        return TAPi18n.__("mastered_today_time", {time: moment(hangoutDate).fromNow()}) + ' - ';
+        return TAPi18n.__("mastered_today_time", {
+          time: moment(hangoutDate).fromNow()
+        }) + ' - ';
       else
-        return TAPi18n.__("mastered_x_days_ago", {days: daysDiff}) + ' - ';
+        return TAPi18n.__("mastered_x_days_ago", {
+          days: daysDiff
+        }) + ' - ';
     } else {
       return '';
     }
@@ -108,30 +112,31 @@ Template.hangoutItem.events({
     }
   },
 
-  'click .delete-hangout': function (event, template) {
+  'click .delete-hangout': function(event, template) {
     sweetAlert({
-      title: TAPi18n.__("delete_hangout_confirm"),
-      text: TAPi18n.__("delete_hangout_text"),
-      showCancelButton: true,
-      cancelButtonText: TAPi18n.__("no_delete_hangout"),
-      confirmButtonText: TAPi18n.__("yes_delete_hangout"),
-      confirmButtonColor: "#d9534f",
-      closeOnConfirm: false,
-      closeOnCancel: true,
-      type: 'warning'
-    },
-    function() {
+        type: 'warning',
+        title: TAPi18n.__("delete_hangout_confirm"),
+        text: TAPi18n.__("delete_hangout_text"),
+        cancelButtonText: TAPi18n.__("no_delete_hangout"),
+        confirmButtonText: TAPi18n.__("yes_delete_hangout"),
+        confirmButtonColor: "#d9534f",
+        showCancelButton: true,
+        closeOnConfirm: false,
+      },
+      function() {
+        // disable confirm button to avoid double (or quick) clicking on confirm event
+        swal.disableButtons();
         // if user confirmed/selected yes, let's call the delete hangout method on the server
         Meteor.call('deleteHangout', template.data._id, function(error, result) {
           if (result) {
             swal("Poof!", "Your hangout has been successfully deleted!", "success");
           } else {
-            swal("Oops something went wrong!", error.error +  "\n Try again", "error");
+            swal("Oops something went wrong!", error.error + "\n Try again", "error");
           }
         });
-      }
-    ); //sweetAlert
+      }); //sweetAlert
   },
+
   'click .edit-hangout': function(e, hangout) {
     //console.log(hangout.data.topic);
     //pass in the right times like 03/09/2016 2:03 AM
@@ -144,7 +149,7 @@ Template.hangoutItem.events({
     Modal.show('editHangoutModal');
     $('#edit-hangout-modal #topic').val(hangout.data.topic);
     $('#edit-hangout-modal #description').val(hangout.data.description);
-    $('#edit-hangout-modal input[value='+hangout.data.type+']').prop("checked", true);
+    $('#edit-hangout-modal input[value=' + hangout.data.type + ']').prop("checked", true);
     $('#edit-hangout-modal #start-date-time').val(start_time_reverted);
     $('#edit-hangout-modal #end-date-time').val(end_time_reverted);
     //console.log(start_time_reverted);
@@ -169,7 +174,7 @@ Template.hangoutItem.events({
       Modal.show('cloneHangoutModal');
       $('#clone-hangout-modal #topic').val(hangout.data.topic);
       $('#clone-hangout-modal #description').val(hangout.data.description);
-      $('#clone-hangout-modal input[value='+hangout.data.type+']').prop("checked", true);
+      $('#clone-hangout-modal input[value=' + hangout.data.type + ']').prop("checked", true);
       //$('#clone-hangout-modal #start-date-time').val(start_time_reverted);
       //$('#clone-hangout-modal #end-date-time').val(end_time_reverted);
       //console.log(start_time_reverted);


### PR DESCRIPTION
Updated SweetAlert package to a SweetAlert2.  Old (original) repo was outdated and not maintained. New functionality needed to disable buttons and show loader on confirm in modal.  

**Separate issue on delete**
- When clicking on delete icon while on home page, behavior was redirecting to hangout detail page
- Not ideal behavior if hangout was deleted as the page will not refresh on delete
- Removed what appears to be a redundant **"join hangout"** button on ```hangout-item.html``` which was creating the conflict and weird behavior (redirect)

Please test and provide feedback or approve merge.