### PR TITLE
Datetime picker behaviour corrected.

### DIFF
--- a/client/templates/hangout/hangout-modal.js
+++ b/client/templates/hangout/hangout-modal.js
@@ -1,24 +1,32 @@
 Template.createHangoutModal.rendered = function() {
   var start = this.$('#start-date-time-picker');
   var end = this.$('#end-date-time-picker');
-  var dateFrom = new Date();
-  var dateTo = new Date();
-  dateTo.setHours(dateTo.getHours()+1);
+
   start.datetimepicker({
-    ignoreReadonly: true
+    ignoreReadonly: true,
+    widgetPositioning: { horizontal: 'auto', vertical: 'bottom'},
+    minDate: new Date()
   });
+
   end.datetimepicker({
     ignoreReadonly: true,
-    useCurrent: false
+    widgetPositioning: { horizontal: 'auto', vertical: 'bottom'},
+    minDate: new Date()
   });
+
   start.on("dp.change", function (e) {
-    end.data("DateTimePicker").minDate(e.date);
+    //current start date & time
+    var minEndDate = new Date(e.date.valueOf());
+    // min time duration of hangout in hours
+    var interval = 1
+    //min end date & time = current start date & time + interval
+    minEndDate.setHours(minEndDate.getHours() + interval);
+    //setting end date & time
+    end.data("DateTimePicker").date(minEndDate);
+    //setting end date & time minLimit
+    end.data("DateTimePicker").minDate(minEndDate);
   });
-  end.on("dp.change", function (e) {
-    start.data("DateTimePicker").maxDate(e.date);
-  });
-  start.data("DateTimePicker").date(dateFrom);
-  end.data("DateTimePicker").date(dateTo);
+
 };
 
 Template.createHangoutModal.events({


### PR DESCRIPTION
#100
issue: 

> when creating a new hangout, the datetime picker logic defaults the end time to current time + 1 hour. The issue is a user is unable to set the start time to some time in the future greater than the default end time.


solution: 
The issues was occurring because we were setting a end time for hangout on template renter,
It should happen on change event of start time.