### PR TITLE
Issue 194 - update study session topic text to read question/goal

### DIFF
--- a/client/templates/hangout/hangout-modal.html
+++ b/client/templates/hangout/hangout-modal.html
@@ -26,7 +26,7 @@
               <br>
               <div class="row">
                 <div class="col-md-12">
-                  <input id="topic" class="form-control" type="text" placeholder="Study Session Topic">
+                  <input id="topic" class="form-control" type="text" placeholder="Question/Goal">
                 </div>
               </div>
               <br>


### PR DESCRIPTION
Per issue 194, I updated the field in the hangout creation modal to read "Question/Goal" rather then "Study Session Topic"