### PR TITLE
Fix logo image on hangout reminder email notification

### DIFF
--- a/server/email/methods.js
+++ b/server/email/methods.js
@@ -14,7 +14,7 @@ emailNotification = function(hangout, type){
     hangout_topic: hangout.topic,
     host: hangout.host.name,
     hangout_start_time: moment.utc( hangout.start ).format('MMMM Do YYYY, h:mm a z'),
-    logo: Meteor.absoluteUrl('images/cb2-180.png'),
+    logo: Meteor.absoluteUrl('images/logo-new.png'),
     hangout_url: Meteor.absoluteUrl("hangout/" + hangout._id)
   };
 

--- a/server/email/methods.js
+++ b/server/email/methods.js
@@ -14,7 +14,7 @@ emailNotification = function(hangout, type){
     hangout_topic: hangout.topic,
     host: hangout.host.name,
     hangout_start_time: moment.utc( hangout.start ).format('MMMM Do YYYY, h:mm a z'),
-    logo: Meteor.absoluteUrl('images/logo-new.png'),
+    logo: Meteor.absoluteUrl('images/logo.png'),
     hangout_url: Meteor.absoluteUrl("hangout/" + hangout._id)
   };
 


### PR DESCRIPTION
Changes the link src image over to the new logo in `/public/images/logo.png`.