### PR TITLE
fixed count users(join) in hangout

### DIFF
--- a/client/templates/hangout/hangout-item.js
+++ b/client/templates/hangout/hangout-item.js
@@ -56,7 +56,7 @@ Template.hangoutItem.helpers({
       ' - ' +
       moment(hangout.end).tz(tz).format('MMMM Do h:mm a z') +
       ' | ' +
-      hangout.attendees.length +
+      hangout.users.length +
       ' joined';
   },
   isInProgress: function(hangout) {


### PR DESCRIPTION
In hangouts listing page, i fix the RSVP count for a hangout to match with actual RSVP counts shown in the hangout's detail page (located in client/templates/status/update-status.html) . And the test is shown below. 
<img width="691" alt="screen shot 2016-09-30 at 3 53 09 pm" src="https://cloud.githubusercontent.com/assets/14363648/19003862/2060889a-8729-11e6-8c6d-28cdd83a2a7a.png">
<img width="1078" alt="screen shot 2016-09-30 at 3 53 24 pm" src="https://cloud.githubusercontent.com/assets/14363648/19003869/20988254-8729-11e6-907d-ac4a2ece7ee0.png">

This is my first pull-request, thanks for opportunity.