### PR TITLE
disabled : default logging

### DIFF
--- a/client/templates/main.js
+++ b/client/templates/main.js
@@ -1,3 +1,11 @@
+if (Meteor.isClient) {
+  Meteor.startup(function () {
+    if(!Meteor.settings.public.isModeDebug){
+      console = console || {};
+      console.log = function(){};
+    }
+  });
+}
 Tracker.autorun(function() {
 
   if (Session.get('hangoutSearchQuery'))

--- a/settings-development.json
+++ b/settings-development.json
@@ -1,4 +1,7 @@
 {
+  "public":{
+    "isModeDebug": false
+  },
   "private": {
     "mailchimp": {
       "apiKey": "mailchimp-api-key",


### PR DESCRIPTION
Disable Logging in Production. #250 
Added environment variable`isModeDebug` into seetings file.
Default logging preferance is `false`
For enable logging set `isModeDebug` to `true`.
