### PR TITLE
Issue-118: Tab alignment fix

### DIFF
--- a/client/css/_tabs.scss
+++ b/client/css/_tabs.scss
@@ -1,5 +1,6 @@
 .full-width-tab {
-  width:100%;
+  width:50%;
+  padding-bottom:1px;
 }
 
 .full-width-tabs {
@@ -7,11 +8,9 @@
   ul.nav.nav-tabs {
     display: table;
     width: 100%;
-    table-layout: fixed;
   }
 
   ul.nav.nav-tabs > li {
-    float: none;
     display: table-cell;
   }
 


### PR DESCRIPTION
This issue comes up when the div that wraps the two tabs is uneven amount of pixels wide. At least with Chrome the 'odd' pixel was left out when float was none. 