### PR TITLE
add sort to client side finder for hangouts

### DIFF
--- a/client/templates/hangout/hangout-list.js
+++ b/client/templates/hangout/hangout-list.js
@@ -16,7 +16,7 @@ Template.hangoutList.onRendered(function() {
 
     instance.loadHangouts = function() {
 
-      return Hangouts.find();
+      return Hangouts.find({}, {sort: {start: -1}});
     }
 
     instance.addMoreHangouts = function(){


### PR DESCRIPTION
this should be working.  Hangouts were being sorted on the server side, but not on the client, so when a new hangout was created it wasn't sorted until page refresh.  