### PR TITLE
Fixes issue 286 : slack notifications with time left

### DIFF
--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -27,6 +27,52 @@ slackNotification = function(hangout, type){
      pretext = `A new *${hangout.type}* hangout has been scheduled by <@${hangout.host.name}>!`;
   }
 
+  let date_start, now_value, now_formatted_time, difference, minutes;
+  date_start = moment.utc(hangout.start);
+  now_value = (moment.utc()); //.format('MMMM Do YYYY, h:mm a z');
+  now_formatted_time = (moment.utc()).format('MMMM Do YYYY, h:mm a z');
+  difference = (moment.duration(date_start.diff(now_value)));
+  minutes = difference.asMinutes();
+
+  if (minutes  >= 60){
+     var hours_whole = difference.asHours();
+     var hours = Math.floor(hours_whole);
+     var rem = Math.floor((minutes - hours*60));
+     var days_whole = difference.asDays();
+     var days = Math.floor(days_whole);
+     var rem_hours = Math.floor((hours_whole - days*24));
+
+     if(hours == 1){   //Singular
+         var time_left = hours +' hr & '+rem+' mins left';
+     }
+     else if(hours > 1 && hours < 24 ) {    //Plural
+         var time_left = hours +' hrs & '+rem+' mins left';
+     }
+
+     else if(hours >=24 && days == 1){
+         var time_left = days +' day, '+rem_hours+' hours & '+rem+' minutes left';
+     }
+     else if(hours >=24 && days > 1){
+       var time_left = days +' days, '+rem_hours+' hours & '+rem+' minutes left';
+     }
+  }
+
+  else if (minutes >=0 && minutes < 60){
+     var rem = Math.floor(minutes);
+
+     if((minutes >= 0 && minutes < 1))
+     {
+       var time_left = 'Hangout starts now!';
+     }
+     else {
+       var time_left = (rem+1)+' mins left';
+     }
+  }
+
+  else if(minutes<0){
+     var time_left = 'This hangout is over!';
+  }
+
   let data = {
      attachments: [{
        fallback: fallback,
@@ -41,12 +87,14 @@ slackNotification = function(hangout, type){
          short: true
        },{
          title: 'Date',
-         value: `${moment.utc(hangout.start).format('MMMM Do YYYY, h:mm a z')}`,
+         value: `${now_formatted_time + '\n ('+time_left+')'}`,
          short: true
        }]
     }]
   }//data
 
+  if(minutes > 0)
+  {
   hangoutAlert(data)
-
+  }
 }//slackNotification();

--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -65,7 +65,7 @@ slackNotification = function(hangout, type){
        var time_left = 'Hangout starts now!';
      }
      else {
-       var time_left = (rem+1)+' mins left';
+       var time_left = 'Starts in '+(rem+1)+' mins!';
      }
   }
 

--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -69,10 +69,6 @@ slackNotification = function(hangout, type){
      }
   }
 
-  else if(minutes<0){
-     var time_left = 'This hangout is over!';
-  }
-
   let data = {
      attachments: [{
        fallback: fallback,

--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -43,17 +43,17 @@ slackNotification = function(hangout, type){
      var rem_hours = Math.floor((hours_whole - days*24));
 
      if(hours == 1){   //Singular
-         var time_left = hours +' hr & '+rem+' mins left';
+         var time_left = 'Starts in '+hours +' hr & '+rem+' mins!';
      }
      else if(hours > 1 && hours < 24 ) {    //Plural
-         var time_left = hours +' hrs & '+rem+' mins left';
+         var time_left = 'Starts in '+hours +' hrs & '+rem+' mins!';
      }
 
      else if(hours >=24 && days == 1){
-         var time_left = days +' day, '+rem_hours+' hours & '+rem+' minutes left';
+         var time_left = 'Starts in '+days +' day, '+rem_hours+' hrs & '+rem+' mins!';
      }
      else if(hours >=24 && days > 1){
-       var time_left = days +' days, '+rem_hours+' hours & '+rem+' minutes left';
+       var time_left = 'Starts in '+days +' days, '+rem_hours+' hrs & '+rem+' mins!';
      }
   }
 


### PR DESCRIPTION
Fixes issue #286 .

Slack notifications now have the time left in terms of days/hours/ minutes as applicable.

![screen shot 2016-10-09 at 9 22 36 pm](https://cloud.githubusercontent.com/assets/342533/19221738/97d3a238-8e66-11e6-8e58-b176009061f2.png)
