### PR TITLE
Fixing broken logo in email template

### DIFF
--- a/private/email-hangout-alerts.html
+++ b/private/email-hangout-alerts.html
@@ -578,7 +578,7 @@
                         <tbody><tr>
                             <td class="mcnImageContent" valign="top" style="padding-right: 9px; padding-left: 9px; padding-top: 0; padding-bottom: 0; text-align:center;">
 
-                                        <img align="center" alt="" src="http://codebuddies.org/images/cb-logo.jpg" width="180" style="max-width:180px; padding-bottom: 0; display: inline !important; vertical-align: bottom;" class="mcnImage">
+                                        <img align="center" alt="" src="http://codebuddies.org/images/logo-circle.png" width="180" style="max-width:180px; padding-bottom: 0; display: inline !important; vertical-align: bottom;" class="mcnImage">
 
 
                             </td>


### PR DESCRIPTION
Fixes #340 

**What does this PR do?**

- Fixes the broken logo that wasn't rendering in the email. 
- turns out, the path to the logo was either unavailable or updated
- changed the old logo `<img src="">` to use the `svg`  I found in `/public/images`