### PR TITLE
added 5px padding to the social links

### DIFF
--- a/client/css/_about.scss
+++ b/client/css/_about.scss
@@ -45,6 +45,9 @@
     .popover:hover {
       cursor: default;
     }
+    .fa {
+      padding: 0px 5px 0px 5px;
+    }
   }
 
   h3.popover-title { margin-top: 0px;}


### PR DESCRIPTION
This addresses issue 351 and adds a small 5px padding to the left and right of the social icons on the about page