### PR TITLE
Issue 363 footer layout

### DIFF
--- a/client/css/_base.scss
+++ b/client/css/_base.scss
@@ -14,7 +14,7 @@ html, body {
 #wrapper {
   position: relative;
   min-height: 100%;
-  padding: 0 0 75px;
+  padding: 0 0;
 }
 
 .auto-height {

--- a/client/css/_colors.scss
+++ b/client/css/_colors.scss
@@ -7,7 +7,7 @@ $cta-blue: #1e90ff;
 $light-blue: #5eafff;
 $kudo: #9b9b9b;
 $primary-grey: #4a4a4a;
-$secondary-grey: #4c4c4c;
+$secondary-grey: #8e8e8e;
 $hangout-teaching: #f5a623;
 $hangout-collab: #7ed321;
 $hangout-silent: #d9534f;

--- a/client/css/_footer.scss
+++ b/client/css/_footer.scss
@@ -2,28 +2,45 @@
   position: absolute;
   bottom: 0;
   width: 100%;
-  min-height: 75px;
+//  min-height: 75px;
   background: $bg-white;
-  padding: 20px 0;
-  @include breakpoint(xsmall) { position: relative;}
+  padding: 50px 0;
+//  @include breakpoint(xsmall) { position: relative;}
   @include font-face(400, 13px, normal, $primary-grey);
-  a {color: $cta-blue; text-decoration: underline;}
+//  a {color: $cta-blue; text-decoration: underline;}
   img {width: 12em;}
-  .fa {font-size: 20px; color: $cta-blue; padding-left: 10px;}
+
+  a {
+    display: block;
+    padding-top: 10px;
+  }
+
+  .footer-section {
+    @include breakpoint(tiny) { margin: 20px 0; }
+    @include breakpoint(xsmall) { margin: 40px 0; }
+  }
+
+// column 2
+
+
+// column 3
+  .footer-social {
+    a {display: inline-block;}
+    .fa {font-size: 20px; color: $cta-blue; padding-right: 10px;}
+  }
+
   .footer-icons {
-    @include breakpoint(tiny) { display: block; }
-    @include breakpoint(xsmall) { display: block; }
-  }
-  span.note { display: block; font-size: 12px;}
-  .footer-details{
-    float:right;
-    @include breakpoint(tiny) { float: none; }
-    @include breakpoint(xsmall) { float: none; }
-    .help {
-      @include breakpoint(tiny) { display: block; }
-      @include breakpoint(xsmall) { display: block; }
+    @include breakpoint(tiny) {
+      text-align: center;
+      .fa {padding: 0 5px;}
     }
+    @include breakpoint(xsmall) {
+      text-align: center;
+      .fa {padding: 0 5px;}
+     }
   }
+
   @include breakpoint(tiny) { text-align: center !important; }
   @include breakpoint(xsmall) { text-align: center !important; }
+
 }

--- a/client/css/_footer.scss
+++ b/client/css/_footer.scss
@@ -1,5 +1,6 @@
 #footer {
-  position: absolute;
+  position: relative;
+  border-top: 1px solid $divider;
   bottom: 0;
   width: 100%;
   padding: 50px 0;

--- a/client/css/_footer.scss
+++ b/client/css/_footer.scss
@@ -6,8 +6,7 @@
   background: $bg-white;
   @include breakpoint(xsmall) { position: relative;}
   @include font-face(400, 13px, normal, $primary-grey);
-//  a {color: $cta-blue; text-decoration: underline;}
-  img {width: 12em; padding-bottom: 20px; }
+  img {width: 12em; padding: 20px 0; }
 
   .logo {
     margin-bottom: 20px;
@@ -34,6 +33,8 @@
   .footer-section {
     @include breakpoint(tiny) { margin: 40px 0; }
     @include breakpoint(xsmall) { margin: 40px 0; }
+    @include breakpoint(small) { margin: 40px 0; }
+    @include breakpoint(xmedium) { margin: 40px 0; }
   }
 
 // column 1
@@ -55,16 +56,36 @@
 
   .footer-icons {
     @include breakpoint(tiny) {
-      text-align: center;
       .fa {padding: 0 5px;}
     }
     @include breakpoint(xsmall) {
-      text-align: center;
       .fa {padding: 0 5px;}
+     }
+     @include breakpoint(small) {
+       .fa {padding: 0 5px;}
+     }
+     @include breakpoint(xmedium) {
+       .fa {padding: 0 5px;}
      }
   }
 
-  @include breakpoint(tiny) { text-align: center !important; }
-  @include breakpoint(xsmall) { text-align: center !important; }
+  @include breakpoint(tiny) {
+    padding: 0;
+    text-align: center !important;
+    img {padding: 0 0 20px; }
+  }
+  @include breakpoint(xsmall) {
+    padding: 0;
+    text-align: center !important;
+    img {padding: 0 0 20px; }
+  }
+  @include breakpoint(small) {
+    padding: 50px 0;
+    text-align: center !important;
+    img {padding: 20px 0; }
+  }
+  @include breakpoint(xmedium) {
+    text-align: center !important;
+  }
 
 }

--- a/client/css/_footer.scss
+++ b/client/css/_footer.scss
@@ -7,11 +7,8 @@
   background: $bg-lightgrey;
   @include breakpoint(xsmall) { position: relative;}
   @include font-face(400, 13px, normal, $secondary-grey);
-  img {width: 12em; padding: 20px 0; }
 
-  .logo {
-    margin-bottom: 20px;
-  }
+  img {width: 12em; padding: 20px 0; }
 
   a {
     display: block;
@@ -27,23 +24,27 @@
     color: $primary-grey;
   }
 
-// all 3 columns
-  .footer-section {
-    @include breakpoint(tiny) { margin: 40px 0; }
-    @include breakpoint(xsmall) { margin: 40px 0; }
-    @include breakpoint(small) { margin: 40px 0; }
-    @include breakpoint(xmedium) { margin: 40px 0; }
-  }
-
 // column 1
   .footer-logo {
+    padding: 40px 0;
     a {display: inline-block; }
     p {margin: 0; }
+    @include breakpoint(tiny) { margin: 20px 0; }
+    @include breakpoint(xsmall) { margin: 20px 0; }
+    @include breakpoint(small) { margin: 0; padding: 0 0 40px; }
+    @include breakpoint(xmedium) { margin: 0; padding: 0 0 40px; }
+    @include breakpoint(medium) { margin: 0; padding: 0 0 40px; }
+    @include breakpoint(large) { margin: 0; padding: 40px 0; }
   }
 
 // column 2
   .footer-links {
     a {padding-bottom: 10px; }
+
+    @include breakpoint(tiny) { margin: 20px 0; }
+    @include breakpoint(xsmall) { margin: 20px 0; }
+    @include breakpoint(small) { margin: 0 0 20px; }
+    @include breakpoint(xmedium) { margin: 0 0 20px; }
   }
 
 // column 3
@@ -82,17 +83,14 @@
   @include breakpoint(tiny) {
     padding: 0;
     text-align: center !important;
-    img {padding: 0 0 20px; }
   }
   @include breakpoint(xsmall) {
     padding: 0;
     text-align: center !important;
-    img {padding: 0 0 20px; }
   }
   @include breakpoint(small) {
     padding: 50px 0;
     text-align: center !important;
-    img {padding: 20px 0; }
   }
   @include breakpoint(xmedium) {
     text-align: center !important;

--- a/client/css/_footer.scss
+++ b/client/css/_footer.scss
@@ -2,31 +2,55 @@
   position: absolute;
   bottom: 0;
   width: 100%;
-//  min-height: 75px;
-  background: $bg-white;
   padding: 50px 0;
-//  @include breakpoint(xsmall) { position: relative;}
+  background: $bg-white;
+  @include breakpoint(xsmall) { position: relative;}
   @include font-face(400, 13px, normal, $primary-grey);
 //  a {color: $cta-blue; text-decoration: underline;}
-  img {width: 12em;}
+  img {width: 12em; padding-bottom: 20px; }
+
+  .logo {
+    margin-bottom: 20px;
+  }
 
   a {
     display: block;
-    padding-top: 10px;
+    color: $secondary-grey;
+    text-decoration:none;
   }
 
+  a:hover   {color: $cta-blue; text-decoration:none}
+
+  .sponsor {
+    text-decoration: underline;
+  }
+
+  p {
+    margin-bottom: 20px;
+    color: $primary-grey;
+  }
+
+// all 3 columns
   .footer-section {
-    @include breakpoint(tiny) { margin: 20px 0; }
+    @include breakpoint(tiny) { margin: 40px 0; }
     @include breakpoint(xsmall) { margin: 40px 0; }
   }
 
-// column 2
+// column 1
+  .footer-logo {
+    a {display: inline-block; }
+    p {margin: 0; }
+  }
 
+// column 2
+  .footer-links {
+    a {padding-bottom: 10px; }
+  }
 
 // column 3
   .footer-social {
     a {display: inline-block;}
-    .fa {font-size: 20px; color: $cta-blue; padding-right: 10px;}
+    .fa {font-size: 20px; padding-right: 10px;}
   }
 
   .footer-icons {

--- a/client/css/_footer.scss
+++ b/client/css/_footer.scss
@@ -1,12 +1,12 @@
 #footer {
   position: relative;
-  border-top: 1px solid $divider;
+//  border-top: 1px solid $divider;
   bottom: 0;
   width: 100%;
   padding: 50px 0;
-  background: $bg-white;
+  background: $bg-lightgrey;
   @include breakpoint(xsmall) { position: relative;}
-  @include font-face(400, 13px, normal, $primary-grey);
+  @include font-face(400, 13px, normal, $secondary-grey);
   img {width: 12em; padding: 20px 0; }
 
   .logo {
@@ -21,9 +21,6 @@
 
   a:hover   {color: $cta-blue; text-decoration:none}
 
-  .sponsor {
-    text-decoration: underline;
-  }
 
   p {
     margin-bottom: 20px;
@@ -70,6 +67,18 @@
      }
   }
 
+// bottom sponsor section
+  .footer-sponsor {
+    border-top: 1px solid $divider;
+    margin-top: 50px;
+    padding-top: 15px;
+
+    a {display: inline-block; }
+    p {color: $secondary-grey; }
+  }
+
+
+// media queries
   @include breakpoint(tiny) {
     padding: 0;
     text-align: center !important;

--- a/client/templates/home/footer.html
+++ b/client/templates/home/footer.html
@@ -1,23 +1,36 @@
 <template name="footer">
 
   <div id="footer">
-    <div class="container">
-      <div class="row">
-        <div class="col-md-12">
-          <a class="logo" href="{{pathFor 'home'}}"><img src="/images/logo.svg"></a>
-          <div class="footer-details">
-            <em>Built by Cool People Around the World</em>
-            <span class="footer-icons">
-              <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch" target="_blank"><i class="fa fa-github"></i></a>
-              <a href="https://codebuddiesmeet.slack.com" target="_blank"><i class="fa fa-slack"></i></a>
-              <a href="https://twitter.com/codebuddiesmeet" target="_blank"><i class="fa fa-twitter"></i></a>
-              <a href="https://www.facebook.com/groups/TOPSTUDYGROUP/" target="_blank"><i class="fa fa-facebook"></i></a>
-            </span>
-            <span class="note">Our project is free and open-sourced. <span class="help"><a href="http://opencollective.com/codebuddies" target="_blank">Help us keep this project alive!</a> | <a href="/privacy">Privacy policy</a></span></span>
-            
+      <div class="container">
+
+        <div class="row">
+          <div class="col-md-6"> <!-- column 1 -->
+            <div class="footer-logo footer-section">
+              <a class="logo" href="{{pathFor 'home'}}"><img src="/images/logo.svg"></a>
+              <span class="note">Our project is free and open-sourced. <span><a href="http://opencollective.com/codebuddies" target="_blank">Help us keep this project alive!</a></span></span>
+            </div>
           </div>
-        </div>
-      </div>
+          <div class="col-md-3"> <!-- column 2 -->
+            <div class="footer-links footer-section">
+              <p><strong>ORGANIZATION</strong></p>
+                <a href="/about">About Us</a>
+                <a href="/faq">FAQ</a>
+                <a href="/privacy">Privacy policy</a>
+            </div>
+          </div>
+          <div class="col-md-3"> <!-- column 3 -->
+            <div class="footer-social footer-section">
+              <p><strong>CONNECT WITH US</strong></p>
+              <span class="footer-icons">
+                <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch" target="_blank"><i class="fa fa-github"></i></a>
+                <a href="https://codebuddiesmeet.slack.com" target="_blank"><i class="fa fa-slack"></i></a>
+                <a href="https://twitter.com/codebuddiesmeet" target="_blank"><i class="fa fa-twitter"></i></a>
+                <a href="https://www.facebook.com/groups/TOPSTUDYGROUP/" target="_blank"><i class="fa fa-facebook"></i></a>
+              </span>
+            </div>
+          </div>
+        </div> <!-- ends row -->
+
     </div>
   </div>
 

--- a/client/templates/home/footer.html
+++ b/client/templates/home/footer.html
@@ -6,8 +6,9 @@
         <div class="row">
           <div class="col-md-6"> <!-- column 1 -->
             <div class="footer-logo footer-section">
-              <a class="logo" href="{{pathFor 'home'}}"><img src="/images/logo.svg"></a>
-              <span class="note">Our project is free and open-sourced. <span><a href="http://opencollective.com/codebuddies" target="_blank">Help us keep this project alive!</a></span></span>
+              <p class="logo" href="{{pathFor 'home'}}"><img src="/images/logo.svg"></p>
+              <p>Our project is free and open-sourced.</p>
+              <p>Help keep this project alive by <a class="sponsor" href="http://opencollective.com/codebuddies" target="_blank">sponsoring us!</a></p>
             </div>
           </div>
           <div class="col-md-3"> <!-- column 2 -->
@@ -15,17 +16,17 @@
               <p><strong>ORGANIZATION</strong></p>
                 <a href="/about">About Us</a>
                 <a href="/faq">FAQ</a>
-                <a href="/privacy">Privacy policy</a>
+                <a href="/privacy">Privacy Policy</a>
             </div>
           </div>
           <div class="col-md-3"> <!-- column 3 -->
             <div class="footer-social footer-section">
               <p><strong>CONNECT WITH US</strong></p>
               <span class="footer-icons">
-                <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch" target="_blank"><i class="fa fa-github"></i></a>
-                <a href="https://codebuddiesmeet.slack.com" target="_blank"><i class="fa fa-slack"></i></a>
-                <a href="https://twitter.com/codebuddiesmeet" target="_blank"><i class="fa fa-twitter"></i></a>
-                <a href="https://www.facebook.com/groups/TOPSTUDYGROUP/" target="_blank"><i class="fa fa-facebook"></i></a>
+                  <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch" target="_blank"><i class="fa fa-github"></i></a>
+                  <a href="https://codebuddiesmeet.slack.com" target="_blank"><i class="fa fa-slack"></i></a>
+                  <a href="https://twitter.com/codebuddiesmeet" target="_blank"><i class="fa fa-twitter"></i></a>
+                  <a href="https://www.facebook.com/groups/TOPSTUDYGROUP/" target="_blank"><i class="fa fa-facebook"></i></a>
               </span>
             </div>
           </div>

--- a/client/templates/home/footer.html
+++ b/client/templates/home/footer.html
@@ -5,12 +5,12 @@
 
         <div class="row">
           <div class="col-md-6"> <!-- column 1 -->
-            <div class="footer-logo footer-section">
-              <p class="logo" href="{{pathFor 'home'}}"><img src="/images/logo.svg"></p>
+            <div class="footer-logo">
+              <p href="{{pathFor 'home'}}"><img src="/images/logo.svg"></p>
             </div>
           </div>
           <div class="col-md-3"> <!-- column 2 -->
-            <div class="footer-links footer-section">
+            <div class="footer-links">
               <p><strong>ORGANIZATION</strong></p>
                 <a href="/about">About Us</a>
                 <a href="/faq">FAQ</a>
@@ -18,7 +18,7 @@
             </div>
           </div>
           <div class="col-md-3"> <!-- column 3 -->
-            <div class="footer-social footer-section">
+            <div class="footer-social">
               <p><strong>CONNECT WITH US</strong></p>
               <span class="footer-icons">
                   <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch" target="_blank"><i class="fa fa-github"></i></a>

--- a/client/templates/home/footer.html
+++ b/client/templates/home/footer.html
@@ -7,8 +7,6 @@
           <div class="col-md-6"> <!-- column 1 -->
             <div class="footer-logo footer-section">
               <p class="logo" href="{{pathFor 'home'}}"><img src="/images/logo.svg"></p>
-              <p>Our project is free and open-sourced.</p>
-              <p>Help keep this project alive by <a class="sponsor" href="http://opencollective.com/codebuddies" target="_blank">sponsoring us!</a></p>
             </div>
           </div>
           <div class="col-md-3"> <!-- column 2 -->
@@ -28,6 +26,14 @@
                   <a href="https://twitter.com/codebuddiesmeet" target="_blank"><i class="fa fa-twitter"></i></a>
                   <a href="https://www.facebook.com/groups/TOPSTUDYGROUP/" target="_blank"><i class="fa fa-facebook"></i></a>
               </span>
+            </div>
+          </div>
+        </div> <!-- ends row -->
+
+        <div class="row align-center">
+          <div class="col-md-12"> <!-- bottom sponsor section -->
+            <div class="footer-sponsor">
+              <p>Our project is free and open-sourced. Help keep this project alive by <a class="sponsor" href="http://opencollective.com/codebuddies" target="_blank"><strong>sponsoring us!</strong></a></p>
             </div>
           </div>
         </div> <!-- ends row -->


### PR DESCRIPTION
Fixes #363 

Restructured the footer layout to have more useful links.

Changed the footer layout to have 3 columns:
column 1: logo
column 2: links
column 3: social media icon links

I updated the media queries for the footer, but I would like someone to review the code to see if there's anything that could be improved.

Additionally, I changed the hex code in the color variable `$secondary-grey` so that it's more visibly different from `$primary-grey` !

Note: We should probably change the top nav links to use `$secondary-grey` instead of the `$cta-blue`. That way we reserve the cta-blue for the important CTA buttons. I could make another PR for this, or someone else can if they see this first.