### PR TITLE
Fix for issue #339 

### DIFF
--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -34,7 +34,10 @@ slackNotification = function(hangout, type){
   now_formatted_time = (moment.utc()).format('MMMM Do YYYY, h:mm a z');
   difference = (moment.duration(date_start.diff(now_value)));
   minutes = difference.asMinutes();
-
+  if (minutes < 0) { // this is to protect from time being in the past (negative number)
+    minutes = Math.abs(minutes) + minutes;
+    // console.log("this was negative and changed it to: " + minutes);
+  }
   if (minutes  >= 60){
      var hours_whole = difference.asHours();
      var hours = Math.floor(hours_whole);
@@ -61,7 +64,7 @@ slackNotification = function(hangout, type){
   else if (minutes >=0 && minutes < 60){
      var rem = Math.floor(minutes);
 
-     if((minutes >= 0 && minutes < 1))
+     if(minutes >= 0 && minutes < 1)
      {
        var time_left = 'Hangout starts now!';
      }
@@ -90,7 +93,7 @@ slackNotification = function(hangout, type){
     }]
   }//data
 
-  if(minutes > 0)
+  if(minutes >= 0)
   {
   hangoutAlert(data)
   }


### PR DESCRIPTION
Fixes #339 

Issue was related to the time difference being calculated between the hangout start time and the server `now` datetime in `minutes`. 

If the user does not change the start time for the hangout but spends a couple minutes filling out the hangout details before clicking on the 'create hangout' button, the difference in `minutes` will actually return a _negative_ integer since the time is now in the past.

Updated logic to compensate for this. If negative, set `minutes` to **0** and ensure if statement checks for `>= 0`

Please review and test!
