### PR TITLE
Fixes odd status-list div css issue

### DIFF
--- a/client/css/_status_input.scss
+++ b/client/css/_status_input.scss
@@ -31,8 +31,7 @@ input:focus, textarea:focus {
     top: -10px;
     padding-right: 5px;
   }
-  span.learnedCharactersLeft {
-  }
+
   #status-buttons { 
     position: relative;
     top: -10px;

--- a/client/css/_status_input.scss
+++ b/client/css/_status_input.scss
@@ -27,12 +27,11 @@ input:focus, textarea:focus {
   }
 
   span.charactersLeft {
-    margin-left: 90px;
     position: relative;
-    top: -20px;
+    top: -10px;
+    padding-right: 5px;
   }
   span.learnedCharactersLeft {
-    margin-left: 300px;
   }
   #status-buttons { 
     position: relative;

--- a/client/templates/status/update-status.html
+++ b/client/templates/status/update-status.html
@@ -5,15 +5,16 @@
     <div class="status-actions">
         {{#if isWorking type}}
         <!--Character counter for 140 character limit-->
-        <span class="charactersLeft">{{characterCount}}</span>
-        <span class="interest">What are you in the mood for? </span>
-        <button class="btn btn-circle btn-danger btn-outline btn-hangout-status silent-tooltip silent-arrow" data-type="silent" data-toggle="tooltip" data-placement="top" title="'Silent' google hangout: I want to motivate myself to get through a tutorial with others who are learning from the same tutorial, OR simply participate in a fun, silent coworking experience."><i class="fa fa-microphone-slash"></i></button>
-        <button class="btn btn-circle btn-warning btn-outline btn-hangout-status teach-tooltip" data-type="teaching" data-toggle="tooltip" data-placement="top" title="'Teaching' google hangout: I want to practice teaching a concept, or walk participants through a codebase. Basically, I'm in the mood for creating a hangout to share what I know!"><i class="fa fa-user"></i></button>
-        <button class="btn btn-circle btn-success btn-outline btn-hangout-status collab-tooltip" data-type="collaboration" data-toggle="tooltip" data-placement="top" title="'Collaboration' google hangout: I want to pair program on a coding exercise, talk through a chapter of a tutorial, or work on an open-sourced project with others."><i class="fa fa-users"></i></button>
-		    {{else}}
-        <!--Character counter for learned 140 character limit-->
-        <span class="learnedCharactersLeft">{{learnedCharacterCount}}</span>
+            <span class="interest">What are you in the mood for? </span>
+            <button class="btn btn-circle btn-danger btn-outline btn-hangout-status silent-tooltip silent-arrow" data-type="silent" data-toggle="tooltip" data-placement="top" title="'Silent' google hangout: I want to motivate myself to get through a tutorial with others who are learning from the same tutorial, OR simply participate in a fun, silent coworking experience."><i class="fa fa-microphone-slash"></i></button>
+            <button class="btn btn-circle btn-warning btn-outline btn-hangout-status teach-tooltip" data-type="teaching" data-toggle="tooltip" data-placement="top" title="'Teaching' google hangout: I want to practice teaching a concept, or walk participants through a codebase. Basically, I'm in the mood for creating a hangout to share what I know!"><i class="fa fa-user"></i></button>
+            <button class="btn btn-circle btn-success btn-outline btn-hangout-status collab-tooltip" data-type="collaboration" data-toggle="tooltip" data-placement="top" title="'Collaboration' google hangout: I want to pair program on a coding exercise, talk through a chapter of a tutorial, or work on an open-sourced project with others."><i class="fa fa-users"></i></button>
+            <span class="charactersLeft">{{characterCount}}</span>
+		{{else}}
+            <!--Character counter for learned 140 character limit-->
+            <span class="learnedCharactersLeft">{{learnedCharacterCount}}</span>
         {{/if}}
+
         <button id="update-{{type}}-btn" class="btn btn-cb2 pull-right">{{_ "update"}}</button>
     </div>
 </template>

--- a/client/templates/status/update-status.html
+++ b/client/templates/status/update-status.html
@@ -4,12 +4,12 @@
     </div>
     <div class="status-actions">
         {{#if isWorking type}}
+        <!--Character counter for 140 character limit-->
+        <span class="charactersLeft">{{characterCount}}</span>
         <span class="interest">What are you in the mood for? </span>
         <button class="btn btn-circle btn-danger btn-outline btn-hangout-status silent-tooltip silent-arrow" data-type="silent" data-toggle="tooltip" data-placement="top" title="'Silent' google hangout: I want to motivate myself to get through a tutorial with others who are learning from the same tutorial, OR simply participate in a fun, silent coworking experience."><i class="fa fa-microphone-slash"></i></button>
         <button class="btn btn-circle btn-warning btn-outline btn-hangout-status teach-tooltip" data-type="teaching" data-toggle="tooltip" data-placement="top" title="'Teaching' google hangout: I want to practice teaching a concept, or walk participants through a codebase. Basically, I'm in the mood for creating a hangout to share what I know!"><i class="fa fa-user"></i></button>
         <button class="btn btn-circle btn-success btn-outline btn-hangout-status collab-tooltip" data-type="collaboration" data-toggle="tooltip" data-placement="top" title="'Collaboration' google hangout: I want to pair program on a coding exercise, talk through a chapter of a tutorial, or work on an open-sourced project with others."><i class="fa fa-users"></i></button>
-        <!--Character counter for 140 character limit-->
-        <span class="charactersLeft">{{characterCount}}</span>
 		    {{else}}
         <!--Character counter for learned 140 character limit-->
         <span class="learnedCharactersLeft">{{learnedCharacterCount}}</span>

--- a/client/templates/status/update-status.js
+++ b/client/templates/status/update-status.js
@@ -22,7 +22,7 @@ Template.updateStatus.events({
         //Check value and if 140 characters have been typed, the user can't type anymore
         var currentLength = $("#working-text").val().length;
         workingCounterValue = maxChars - currentLength;
-        console.log(workingCounterValue);
+        //console.log(workingCounterValue);
         $('.charactersLeft').text(workingCounterValue);
     },
     'keyup #learned-text': function(event) {


### PR DESCRIPTION
Fixes #298.

Moving the character count to the right in a previous PR caused an overflow issue when the screen size was smaller. Adjusted the location of the character count to be on the left side of the status-list box. 