### PR TITLE
Remove dodgerblue background on "Upcoming" in single post page

### DIFF
--- a/client/css/_post.scss
+++ b/client/css/_post.scss
@@ -10,24 +10,24 @@
     color: $warm-grey;
     .img-circle { width: 50px; }
   }
-  
+
   textarea#newMessage { min-height: 100px; margin-bottom: 10px;}
   select#commentFilter { margin-bottom: 10px;}
   span.cb-delete:hover { cursor: pointer;}
   ol{
-    padding-left: 16px; 
+    padding-left: 16px;
     font-weight: 200;
   }
   .hangout-status { text-align: center; }
-  .hangout-status p { 
-    background: $dodgerblue;
+  .hangout-status p {
+    background: $bg-white;
     text-align: center;
     padding: 10px 0;
     font-size: 18px;
     @include border-radius(3px);
     margin: 0px;
     font-weight: 200;
-    color: $white;
+    color: $primary-grey;
     a {
       color: $white;
       text-decoration: underline;


### PR DESCRIPTION
Fixes #372.

Instead of this:
<img width="1207" alt="screen shot 2016-10-27 at 2 03 07 am" src="https://cloud.githubusercontent.com/assets/13127241/19757638/923d663e-9be9-11e6-9652-57d0460d99c7.png">

The area now looks like this:
<img width="1180" alt="screen shot 2016-10-27 at 2 01 13 am" src="https://cloud.githubusercontent.com/assets/13127241/19757603/6ad3e7ee-9be9-11e6-9fe4-d187ad8f96d7.png">

