### PR TITLE
Fixes on top/bottom area padding & .home-psst mobile

### DIFF
--- a/client/css/_home.scss
+++ b/client/css/_home.scss
@@ -1,7 +1,6 @@
 #home {
   background: $cta-blue;
   padding-top: 50px;
-  padding-bottom: 120px;
 
   p { line-height: 27px; color: $primary-grey; }
 
@@ -56,7 +55,7 @@
   }
 
   .home-top, .home-ask {
-    padding: 120px 0 0 0;
+    padding: 60px 0 0 0;
     background: $dodgerblue;
     overflow: hidden;
     h2 {
@@ -233,5 +232,18 @@
     }
   }
 
+  @media only screen and (max-width: 695px) {
+    .home-psst {
+      h3, p { padding: 0 20px; }
+      .hangout-example { width: 65%; }
+    }
+  }
+
+  @media only screen and (max-width: 530px) {
+    .home-psst {
+      h3, p { padding: 0 20px; }
+      .hangout-example { width: 80%; }
+    }
+  }
 
 }

--- a/client/css/_home.scss
+++ b/client/css/_home.scss
@@ -200,6 +200,10 @@
     p { line-height: 27px; margin-top: 40px;}
     #intro {
       h3 {@include font-face(600, 24px, bold, $primary-grey);}
+      h3, p {
+        @include breakpoint(small) { padding: 0 20px; }
+        @include breakpoint(xsmall) { padding: 0 40px; }
+      }
       text-align: center;
       max-width: 550px;
       margin: 0 auto;
@@ -211,6 +215,8 @@
     }
     .hangout-example {
       width: 50%;
+      @include breakpoint(small) { width: 65%; }
+      @include breakpoint(xsmall) { width: 80%; }
       margin: 0 auto;
     }
   }
@@ -229,20 +235,6 @@
     text-align: center;
     .join-slack {
       margin-top: 50px;
-    }
-  }
-
-  @media only screen and (max-width: 695px) {
-    .home-psst {
-      h3, p { padding: 0 20px; }
-      .hangout-example { width: 65%; }
-    }
-  }
-
-  @media only screen and (max-width: 530px) {
-    .home-psst {
-      h3, p { padding: 0 40px; }
-      .hangout-example { width: 80%; }
     }
   }
 

--- a/client/css/_home.scss
+++ b/client/css/_home.scss
@@ -241,7 +241,7 @@
 
   @media only screen and (max-width: 530px) {
     .home-psst {
-      h3, p { padding: 0 20px; }
+      h3, p { padding: 0 40px; }
       .hangout-example { width: 80%; }
     }
   }


### PR DESCRIPTION
Fixes #374.

Taking @adachiu's advice, I cut the top padding in half from 120px to 60px so it now looks like this:

<img width="1438" alt="screen shot 2016-10-27 at 10 08 17 pm" src="https://cloud.githubusercontent.com/assets/13127241/19793365/e99a2d74-9c91-11e6-9a57-0c5028ad5e18.png">

Padding at the very bottom blue area was removed, and this is how the mobile padding on the .home-psst section is looking on Chrome DevTools:

<img width="350" alt="screen shot 2016-10-27 at 10 20 08 pm" src="https://cloud.githubusercontent.com/assets/13127241/19793711/8f58fef6-9c93-11e6-8d37-9d23695613cc.png">

<img width="350" alt="screen shot 2016-10-27 at 10 18 47 pm" src="https://cloud.githubusercontent.com/assets/13127241/19793668/613bb1b2-9c93-11e6-9000-6c33024e2ab6.png">

<img width="431" alt="screen shot 2016-10-27 at 10 17 48 pm" src="https://cloud.githubusercontent.com/assets/13127241/19793656/48c0ba38-9c93-11e6-8edd-0cf4fc1c7f92.png">

If the media queries need refactoring to fit a style or something I missed, let me know. I was going by resizing my browser width and adding those two in when the content broke (image again grew too small to really read, needed a bit more left/right padding). Did just notice that I copied the 20px on h3, p padding twice where the second instance should be 40px, so I'll fix that up now and push the commit up (the images above reflect the 40px on phones, not the original 20px). 😅