### PR TITLE
Fix/issue 380 navbar link color

### DIFF
--- a/client/css/_base.scss
+++ b/client/css/_base.scss
@@ -36,6 +36,7 @@ h3 {
 a:hover {
   text-decoration: none;
   cursor: pointer;
+  color: $cta-blue;
 }
 
 .__slackin {

--- a/client/css/_footer.scss
+++ b/client/css/_footer.scss
@@ -16,9 +16,6 @@
     text-decoration:none;
   }
 
-  a:hover   {color: $cta-blue; text-decoration:none}
-
-
   p {
     margin-bottom: 20px;
     color: $primary-grey;

--- a/client/css/_navbar.scss
+++ b/client/css/_navbar.scss
@@ -30,11 +30,6 @@
       margin-top: 4px;
     }
 
-    li > a:hover {
-      @include font-face(400, 18px, normal, $cta-blue);
-      margin-top: 4px;
-    }
-
     li > a > img {
       display: inline-block;
       width: 34px;

--- a/client/css/_navbar.scss
+++ b/client/css/_navbar.scss
@@ -26,6 +26,11 @@
   .navbar-nav {
 
     li > a {
+      @include font-face(400, 18px, normal, $secondary-grey);
+      margin-top: 4px;
+    }
+
+    li > a:hover {
       @include font-face(400, 18px, normal, $cta-blue);
       margin-top: 4px;
     }


### PR DESCRIPTION
Fixes #380 .

In _navbar.scss

  - Change the color variable to $secondary-grey

In _base.scss

 - Update the a:hover color to $cta-blue

In _footer.scss

 - Remove a:hover as it was redundant from _base.scss
