### PR TITLE
Ellipsis Character Number Display on Slack and Homepage

### DIFF
--- a/client/templates/hangout/hangout-item.js
+++ b/client/templates/hangout/hangout-item.js
@@ -31,7 +31,12 @@ Template.registerHelper("hangoutOwner", function(ownerid){
 
 Template.hangoutItem.helpers({
   getDescriptionTruncated: function(description) {
-      return description.substring(0,201)+"...";
+      if(description.length > 201){
+        return description.substring(0,201)+"...";
+      }
+      else {
+        return description.substring(0,201)
+      }
     },
   isInProgress: function(hangout) {
 

--- a/contributing.md
+++ b/contributing.md
@@ -2,31 +2,40 @@
 1. How do I start up the app?
   * `meteor npm install`
   * `meteor --settings settings-development.json`
-  
+
 If you have any problems getting the app to start, feel free to ask in the #troubleshooting channel on the CodeBuddies Slack. (Click [here](http://codebuddiesmeet.herokuapp.com) for an invite to the Slack channel if you're not already on it.) Please mention:
 - your operating system (e.g. Windows, MacOSX, Linux, etc.)
 - which version of meteor you have installed (You can type `meteor --version` in your terminal to check)
 - Whether or not you've run `meteor npm install` before you attempted to start the app.
 
-## The first 6 steps to take if you want to contribute to this open-sourced project:
-1. Add your name on the google doc [bit.ly/codebuddies-hangouts-platform-v2-googledoc](http://bit.ly/codebuddies-hangouts-platform-v2-googledoc) if your name is not listed, and you want to be recognized as a collaborator.
-2. Say hello on the [#codebuddies-meta channel in the Slack](https://codebuddiesmeet.slack.com/messages/codebuddies-meta/). Feel free to ask questions here, or to ask for someone to review your pull request.
-3. [Install Meteor](https://www.meteor.com/install) and Node: [docs.npmjs.com/cli/install](https://docs.npmjs.com/cli/install) if you don't already have them installed.
-4. Please star this repository! We need to reach 100 stars so that we can apply to the [Open Collective](https://opencollective.com/opensource/apply). [Edit - We're already there!]
-5. Fork this repository! Once you have a copy of this repo on your own account, clone this repo to your computer by typing in something like:
+## The Quick Steps on Contributing:
+1. Join the community!
+2. Install meteor and node!
+3. Fork and clone the repository.
+4. Install your development environment.
+5. Create a branch on the issue you want to work on.
+6. (Optional) Add yourself as a contributor to both the README.md and our About page.  
+7. Submit a Pull Request and associate it with the issue.
+
+
+## The more detailed steps to take if you want to contribute to this open-sourced project:
+1. Say hello on the [#codebuddies-meta channel in the Slack](https://codebuddiesmeet.slack.com/messages/codebuddies-meta/). Feel free to ask questions here, or to ask for someone to review your pull request.
+2. [Install Meteor](https://www.meteor.com/install) and Node: [docs.npmjs.com/cli/install](https://docs.npmjs.com/cli/install) if you don't already have them installed.
+3. Please star this repository! We need to reach 100 stars so that we can apply to the [Open Collective](https://opencollective.com/opensource/apply). [Edit - We're already there!]
+4. Fork this repository! Once you have a copy of this repo on your own account, clone this repo to your computer by typing in something like:
   `git clone https://github.com/codebuddiesdotorg/cb-v2-scratch.git`
 (Replace the URL with your own repository URL path.)
-6. Setup this repository as an upstream branch using:
+5. Setup this repository as an upstream branch using:
 `git remote add upstream https://github.com/codebuddiesdotorg/cb-v2-scratch.git`. <br/>
 Now, whenever you want to sync with the owner repository. Do the following:
  * `git fetch upstream`
  * `git checkout master`
  * `git merge upstream/master`
- 
-7. Type `meteor npm install`, and then `meteor --settings settings-development.json` in your terminal to start up the app in your browser (`localhost:3000`). (`npm run meteor:dev` can also run the app, but will likely [use up your CPU](https://github.com/meteor/meteor/issues/4314).)
-8. Look at some of the [open issues](https://github.com/codebuddiesdotorg/cb-v2-scratch/issues) and identify one that sparks your interest. If you want to work on the issue, leave a comment on it saying that you're working on it!
-9. If you have any questions about the issue you're looking at, you can leave a comment in there, or ask in the [#codebuddies-meta Slack channel](https://codebuddiesmeet.slack.com/messages/codebuddies-meta). Read below for more instructions about how to work with branches.
-10. Type `git branch -a` to see a list of all the branches besides `master`, the default branch you're in. Note that if you want to switch to a branch returned in the last, you would type `git checkout BRANCHNAME`. You can read more about how to create a new branch to work on an issue below.
+
+6. Type `meteor npm install`, and then `meteor --settings settings-development.json` in your terminal to start up the app in your browser (`localhost:3000`). (`npm run meteor:dev` can also run the app, but will likely [use up your CPU](https://github.com/meteor/meteor/issues/4314).)
+7. Look at some of the [open issues](https://github.com/codebuddiesdotorg/cb-v2-scratch/issues) and identify one that sparks your interest. If you want to work on the issue, leave a comment on it saying that you're working on it!
+8. If you have any questions about the issue you're looking at, you can leave a comment in there, or ask in the [#codebuddies-meta Slack channel](https://codebuddiesmeet.slack.com/messages/codebuddies-meta). Read below for more instructions about how to work with branches.
+9. Type `git branch -a` to see a list of all the branches besides `master`, the default branch you're in. Note that if you want to switch to a branch returned in the last, you would type `git checkout BRANCHNAME`. You can read more about how to create a new branch to work on an issue below.
 
 If you see a bug in the app or have a feature request, feel free to [create a new issue](https://github.com/codebuddiesdotorg/cb-v2-scratch/issues/new) on the Github repo!
 

--- a/contributing.md
+++ b/contributing.md
@@ -8,34 +8,25 @@ If you have any problems getting the app to start, feel free to ask in the #trou
 - which version of meteor you have installed (You can type `meteor --version` in your terminal to check)
 - Whether or not you've run `meteor npm install` before you attempted to start the app.
 
-## The Quick Steps on Contributing:
-1. Join the community!
-2. Install meteor and node!
-3. Fork and clone the repository.
-4. Install your development environment.
-5. Create a branch on the issue you want to work on.
-6. (Optional) Add yourself as a contributor to both the README.md and our About page.  
-7. Submit a Pull Request and associate it with the issue.
-
-
-## The more detailed steps to take if you want to contribute to this open-sourced project:
-1. Say hello on the [#codebuddies-meta channel in the Slack](https://codebuddiesmeet.slack.com/messages/codebuddies-meta/). Feel free to ask questions here, or to ask for someone to review your pull request.
-2. [Install Meteor](https://www.meteor.com/install) and Node: [docs.npmjs.com/cli/install](https://docs.npmjs.com/cli/install) if you don't already have them installed.
-3. Please star this repository! We need to reach 100 stars so that we can apply to the [Open Collective](https://opencollective.com/opensource/apply). [Edit - We're already there!]
-4. Fork this repository! Once you have a copy of this repo on your own account, clone this repo to your computer by typing in something like:
+## The first 6 steps to take if you want to contribute to this open-sourced project:
+1. Add your name on the google doc [bit.ly/codebuddies-hangouts-platform-v2-googledoc](http://bit.ly/codebuddies-hangouts-platform-v2-googledoc) if your name is not listed, and you want to be recognized as a collaborator.
+2. Say hello on the [#codebuddies-meta channel in the Slack](https://codebuddiesmeet.slack.com/messages/codebuddies-meta/). Feel free to ask questions here, or to ask for someone to review your pull request.
+3. [Install Meteor](https://www.meteor.com/install) and Node: [docs.npmjs.com/cli/install](https://docs.npmjs.com/cli/install) if you don't already have them installed.
+4. Please star this repository! We need to reach 100 stars so that we can apply to the [Open Collective](https://opencollective.com/opensource/apply). [Edit - We're already there!]
+5. Fork this repository! Once you have a copy of this repo on your own account, clone this repo to your computer by typing in something like:
   `git clone https://github.com/codebuddiesdotorg/cb-v2-scratch.git`
 (Replace the URL with your own repository URL path.)
-5. Setup this repository as an upstream branch using:
+6. Setup this repository as an upstream branch using:
 `git remote add upstream https://github.com/codebuddiesdotorg/cb-v2-scratch.git`. <br/>
 Now, whenever you want to sync with the owner repository. Do the following:
  * `git fetch upstream`
  * `git checkout master`
  * `git merge upstream/master`
 
-6. Type `meteor npm install`, and then `meteor --settings settings-development.json` in your terminal to start up the app in your browser (`localhost:3000`). (`npm run meteor:dev` can also run the app, but will likely [use up your CPU](https://github.com/meteor/meteor/issues/4314).)
-7. Look at some of the [open issues](https://github.com/codebuddiesdotorg/cb-v2-scratch/issues) and identify one that sparks your interest. If you want to work on the issue, leave a comment on it saying that you're working on it!
-8. If you have any questions about the issue you're looking at, you can leave a comment in there, or ask in the [#codebuddies-meta Slack channel](https://codebuddiesmeet.slack.com/messages/codebuddies-meta). Read below for more instructions about how to work with branches.
-9. Type `git branch -a` to see a list of all the branches besides `master`, the default branch you're in. Note that if you want to switch to a branch returned in the last, you would type `git checkout BRANCHNAME`. You can read more about how to create a new branch to work on an issue below.
+7. Type `meteor npm install`, and then `meteor --settings settings-development.json` in your terminal to start up the app in your browser (`localhost:3000`). (`npm run meteor:dev` can also run the app, but will likely [use up your CPU](https://github.com/meteor/meteor/issues/4314).)
+8. Look at some of the [open issues](https://github.com/codebuddiesdotorg/cb-v2-scratch/issues) and identify one that sparks your interest. If you want to work on the issue, leave a comment on it saying that you're working on it!
+9. If you have any questions about the issue you're looking at, you can leave a comment in there, or ask in the [#codebuddies-meta Slack channel](https://codebuddiesmeet.slack.com/messages/codebuddies-meta). Read below for more instructions about how to work with branches.
+10. Type `git branch -a` to see a list of all the branches besides `master`, the default branch you're in. Note that if you want to switch to a branch returned in the last, you would type `git checkout BRANCHNAME`. You can read more about how to create a new branch to work on an issue below.
 
 If you see a bug in the app or have a feature request, feel free to [create a new issue](https://github.com/codebuddiesdotorg/cb-v2-scratch/issues/new) on the Github repo!
 

--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -70,17 +70,35 @@ slackNotification = function(hangout, type){
      }
   }
 
+  let hangoutTitle, hangoutDescription;
+  hangoutTitle = hangout.topic;
+  hangoutDescription = hangout.description;
+
+  if(hangoutTitle.length > 101){
+    hangoutTitle = `${hangoutTitle.substr(0,101) + '...'}`;
+  }
+  else {
+    hangoutTitle.substr(0,101);
+  }
+
+  if(hangoutDescription.length > 201){
+    hangoutDescription = `${hangout.description.substr(0,201) + '...'}`;
+  }
+  else {
+    hangoutDescription = `_ ${hangoutDescription.substr(0,201)} _`;
+  }
+
   let data = {
      attachments: [{
        fallback: fallback,
        color: '#1e90ff',
        pretext: pretext,
-       title: `${hangout.topic.substr(0,101) + '...'}`,
+       title: hangoutTitle,
        title_link: Meteor.absoluteUrl("hangout/" + hangout._id),
        mrkdwn_in: ['text', 'pretext', 'fields'],
        fields: [{
          title: 'Description',
-         value: `_ ${hangout.description.substr(0,201) + '...'} _`,
+         value: hangoutDescription,
          short: true
        },{
          title: 'Date',


### PR DESCRIPTION
No issue number. Discussed in #codebuddies-meta.

Ellipsis would show in both the Slack notifications no matter what for descriptions (at 201 character limit) and for title (at 101 character limit _only in Slack_). 

The proposed fix alleviates confusion if the character text is supposed to continue on. 

Note: I wasn't able to get the italics working on the hangout description for Slack. I'm not sure why, but it does provide a nice visual difference of which hangouts have more text than the ones under 201.

Also - not sure how we're versioning our files here. It looks like @sergeant-q had some one filled out for the Slack notification. Let me know if I should bump it up to 0.0.2.