### PR TITLE
Ellipsis Character Number Display on Slack and Homepage

### DIFF
--- a/client/templates/hangout/hangout-item.js
+++ b/client/templates/hangout/hangout-item.js
@@ -15,7 +15,12 @@ Template.registerHelper("hangoutOwner", function(ownerid){
 
 Template.hangoutItem.helpers({
   getDescriptionTruncated: function(description) {
+    if(description.length > 201){
       return description.substring(0,201)+"...";
+    }
+    else {
+      return description.substring(0,201)
+    }
   }
 });
 

--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -111,7 +111,7 @@ slackNotification = function(hangout, type){
     }]
   }//data
 
-  if(minutes > 0)
+  if(minutes >= 0)
   {
   hangoutAlert(data)
   }

--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -73,17 +73,35 @@ slackNotification = function(hangout, type){
      }
   }
 
+  let hangoutTitle, hangoutDescription;
+  hangoutTitle = hangout.topic;
+  hangoutDescription = hangout.description;
+
+  if(hangoutTitle.length > 101){
+    hangoutTitle = `${hangoutTitle.substr(0,101) + '...'}`;
+  }
+  else {
+    hangoutTitle.substr(0,101);
+  }
+
+  if(hangoutDescription.length > 201){
+    hangoutDescription = `${hangout.description.substr(0,201) + '...'}`;
+  }
+  else {
+    hangoutDescription = `_ ${hangoutDescription.substr(0,201)} _`;
+  }
+
   let data = {
      attachments: [{
        fallback: fallback,
        color: '#1e90ff',
        pretext: pretext,
-       title: `${hangout.topic.substr(0,101) + '...'}`,
+       title: hangoutTitle,
        title_link: Meteor.absoluteUrl("hangout/" + hangout._id),
        mrkdwn_in: ['text', 'pretext', 'fields'],
        fields: [{
          title: 'Description',
-         value: `_ ${hangout.description.substr(0,201) + '...'} _`,
+         value: hangoutDescription,
          short: true
        },{
          title: 'Date',
@@ -93,7 +111,7 @@ slackNotification = function(hangout, type){
     }]
   }//data
 
-  if(minutes >= 0)
+  if(minutes > 0)
   {
   hangoutAlert(data)
   }


### PR DESCRIPTION
No issue number. Discussed in #codebuddies-meta.

Ellipsis would show in both the Slack notifications no matter what for descriptions (at 201 character limit) and for title (at 101 character limit only in Slack).

The proposed fix alleviates confusion if the character text is supposed to continue on.

Note: I wasn't able to get the italics working on the hangout description for Slack. I'm not sure why, but it does provide a nice visual difference of which hangouts have more text than the ones under 201.

Also - not sure how we're versioning our files here. It looks like @sergeant-q had one filled out for the Slack notification. Let me know if I should bump it up to 0.0.2.
