### PR TITLE
Remove word-break from status

### DIFF
--- a/client/css/_status_list.scss
+++ b/client/css/_status_list.scss
@@ -52,10 +52,10 @@
     }
 
     .status {
-      padding-left: 10px;
+      padding: .4em;
+      background: white;
       display: inline-block;
       @include font-face(400, 15px, normal, $primary-grey);
-      word-break: break-all;
     }
 
     .status-date {


### PR DESCRIPTION
Hi CodeBuddies!

So, I was posting a status update to the "Today I Learned..." section, and noticed the word-break was making the paragraph look a bit difficult to read. This PR will turn this:

<img width="478" alt="screen shot 2016-11-15 at 1 13 05 pm" src="https://cloud.githubusercontent.com/assets/6667096/20320697/66de305a-ab38-11e6-90c4-ef5280355a32.png">

INTO THIS:

<img width="452" alt="screen shot 2016-11-15 at 1 35 51 pm" src="https://cloud.githubusercontent.com/assets/6667096/20320720/7c42aa98-ab38-11e6-9ae9-2f9cd38dfcf2.png">

Hope this is an improvement :)