### PR TITLE
Corrected grammar in alerts issue #1052

### DIFF
--- a/client/templates/hangout/hangout_action_bar.js
+++ b/client/templates/hangout/hangout_action_bar.js
@@ -95,7 +95,11 @@ Template.hangoutActionBar.events({
       swal.disableButtons();
       if (result.value) {
         Meteor.call("deleteHangout", data, function(error) {
-          swal("Poof!", "Your hangout has been success delete!", "success");
+          swal(
+            "Poof!",
+            "Your hangout has been successfully deleted!",
+            "success"
+          );
         });
       } else if (
         result.dismiss === "cancel" ||

--- a/client/templates/hangout/hangout_action_buttons.js
+++ b/client/templates/hangout/hangout_action_buttons.js
@@ -157,7 +157,11 @@ Template.hangoutActionButtons.events({
 
       if (result.value) {
         Meteor.call("deleteHangout", data, function(error) {
-          swal("Poof!", "Your hangout has been success delete!", "success");
+          swal(
+            "Poof!",
+            "Your hangout has been successfully deleted!",
+            "success"
+          );
         });
       } else if (
         result.dismiss === "cancel" ||
@@ -195,7 +199,11 @@ Template.hangoutActionButtons.events({
       swal.disableButtons();
       if (result.value) {
         Meteor.call("endHangout", data, function(error) {
-          swal("Poof!", "Your hangout has been success delete!", "success");
+          swal(
+            "Poof!",
+            "Your hangout has been successfully deleted!",
+            "success"
+          );
         });
       } else if (
         result.dismiss === "cancel" ||


### PR DESCRIPTION
Fixes #1052.

Corrected the following:
```
client/templates/hangout/hangout_action_buttons.js
160:          swal("Poof!", "Your hangout has been success delete!", "success");
198:          swal("Poof!", "Your hangout has been success delete!", "success");

client/templates/hangout/hangout_action_bar.js
98:          swal("Poof!", "Your hangout has been success delete!", "success");
```

"Your hangout has been success delete" now reads "Your hangout has been successfully deleted."