### PR TITLE
fix - user online count.

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -68,3 +68,4 @@ underscore
 twbs:bootstrap@=3.3.5
 percolate:migrations
 cleandersonlobo:sweetalert2
+mizzao:user-status

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -89,6 +89,8 @@ meteortesting:mocha@1.0.0
 meteortoys:toykit@2.2.1
 minifier-js@2.3.5
 minimongo@1.4.4
+mizzao:timesync@0.3.4
+mizzao:user-status@0.6.8
 mobile-experience@1.0.5
 mobile-status-bar@1.0.14
 modern-browsers@0.1.2

--- a/client/css/_tabs.scss
+++ b/client/css/_tabs.scss
@@ -1,5 +1,5 @@
 .full-width-tab {
-  width: 100%;
+  width: 50%;
   padding-bottom: 1px;
 }
 

--- a/client/templates/home/home_logged_in.html
+++ b/client/templates/home/home_logged_in.html
@@ -69,13 +69,21 @@
       <div class="col-md-4 padding-none">
         <div class="full-width-tabs">
           <ul class="nav nav-tabs" role="tablist">
-            <li role="presentation" class="full-width-tab active"><a href="#userLearningList" aria-controls="userLearningList"
-                role="tab" data-toggle="tab">{{_ "today_i_learned"}}</a></li>
+            <li role="presentation" class="full-width-tab active">
+              <a href="#onlineUserList" aria-controls="onlineUserList" role="tab" data-toggle="tab">{{_ "i_am_working_on"}}</a>
+            </li>
+            <li role="presentation" class="full-width-tab">
+              <a href="#userLearningList" aria-controls="userLearningList" role="tab" data-toggle="tab">{{_ "today_i_learned"}}</a>
+            </li>
           </ul>
 
           <!-- Tab panes -->
           <div class="tab-content">
-            <div role="tabpanel" class="tab-pane active" id="userLearningList">
+            <div role="tabpanel" class="tab-pane active" id="onlineUserList">
+              {{> updateStatus type="working"}}
+              {{> statusList type="working"}}
+            </div>
+            <div role="tabpanel" class="tab-pane" id="userLearningList">
               {{> updateStatus type="learned"}}
               {{> statusList type="learned"}}
             </div>


### PR DESCRIPTION
Fixes #989 , #1080.

mizzao's meteor-user-status package was removed previously because it was not compatible with current version of meteor. Thats no longer the case So adding it back.

Also, adding back `list of online people` section on `/hangouts` page.
<img width="431" alt="screen shot 2018-12-05 at 12 42 25 pm" src="https://user-images.githubusercontent.com/11193792/49496526-34381280-f88c-11e8-85b1-49253069eeb6.png">

