### PR TITLE
Github login debugging

### DIFF
--- a/server/github_api_calls.js
+++ b/server/github_api_calls.js
@@ -4,15 +4,17 @@ githubAuthRevoke = function(accessToken) {
   const clientSecret = Meteor.settings.github_clientsecret;
   const options = {
     headers: {
-      "User-Agent": "CodeBuddies"
+      "User-Agent": "CodeBuddies",
+      "Authorization": `token ${accessToken}`
     },
     auth: `${clientId}:${clientSecret}`
   };
   const response = HTTP.del(
-    `https://api.github.com/applications/${clientId}/grants/${accessToken}`,
+    "https://api.github.com/user/repos",
     options
   );
   const { statusCode = null } = response || {};
+  console.log(response) //Needed for debugging
   return {
     ok: statusCode === 204
   };


### PR DESCRIPTION
Fixes #1171 (hopefully).

This PR follows the guidelines in https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/ to (hopefully) fix the deprecated API authentication method.

Before: 
`curl "https://api.github.com/user/repos?access_token=my_access_token"`

After: 
Send the token in the header like: 

```
curl -H 'Authorization: token my_access_token' https://api.github.com/user/repos
```

It looked like we previously were using the clientId and clientSecret as a query param, so I kept the `auth: `${clientId}:${clientSecret}` and updated the  HTTP call to be `https://api.github.com/user/repos`

![image](https://user-images.githubusercontent.com/4512699/136328323-3d7f7c75-1acd-4c06-91dd-8e5fc1a95ba4.png)

Meteor docs on HTTP: https://docs.meteor.com/api/http.html

Note: this was difficult to debug in localhost:3000, so I'm making the change against `master`. Should be low risk since only the GitHub API call file is affected, and it's already broken.